### PR TITLE
Fix usuario propagation in MainLayout

### DIFF
--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -8,7 +8,7 @@ function MainLayout({ usuario, children }) {
       <Sidebar />
       <Header usuario={usuario} />
       <main className="pl-56 pt-20 pr-6 pb-6">
-        {children}
+        {React.cloneElement(children, { usuario })}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- ensure `MainLayout` passes the `usuario` prop to its children via `React.cloneElement`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ce67193e083249924d752b4260a8f