### PR TITLE
Use usuario prop in Notificaciones

### DIFF
--- a/src/views/Notificaciones.jsx
+++ b/src/views/Notificaciones.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import { db } from "../firebase/config";
 import { collection, query, where, getDocs, updateDoc, doc } from "firebase/firestore";
 
-function Notificaciones() {
-  const usuario = JSON.parse(localStorage.getItem("usuarioManual"));
+function Notificaciones({ usuario }) {
   const [notifs, setNotifs] = useState([]);
   const [cargando, setCargando] = useState(true);
 


### PR DESCRIPTION
## Summary
- use `usuario` prop in `Notificaciones` instead of reading localStorage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ce86e4dd08324a8fb7ed78aba29ad