### PR TITLE
Improve notifications deletion and router

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,12 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./views/App";
 import "./index.css";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `ordenId` field to notifications to link them with work orders
- clean related notifications when deleting an order
- use `HashRouter` to avoid Not Found errors on reload

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d0722a0dc8324a293aacd35c873fd