### PR TITLE
Handle empty categorias snapshots and allow Firestore reads

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /categorias/{document=**} {
+      allow read;
+    }
+  }
+}

--- a/src/modules/ganaderia/Ganaderia.jsx
+++ b/src/modules/ganaderia/Ganaderia.jsx
@@ -90,6 +90,11 @@ function useCategorias(actividad) {
     const unsub = onSnapshot(
       qRef,
       (snap) => {
+        if (snap.empty) {
+          setCategorias([]);
+          setError("Sin datos o permisos");
+          return;
+        }
         const arr = snap.docs.map((d) => {
           const data = d.data();
           const actNorm = normalizeText(data.actividad);
@@ -561,6 +566,12 @@ export default function Ganaderia() {
         {categoriasError && (
           <div className="mb-4 p-2 rounded bg-red-100 text-red-800">
             Error cargando categorías: {categoriasError}
+          </div>
+        )}
+
+        {categorias.length === 0 && !categoriasError && (
+          <div className="mb-4 p-2 rounded bg-yellow-100 text-yellow-800">
+            No hay categorías disponibles
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- show "Sin datos o permisos" when categorias snapshot is empty
- warn UI when no categorias are available
- add Firestore rule permitting reads on categorias

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fdd92089c8324ac57a785f3763378